### PR TITLE
Use GitHub Actions data to power statuses

### DIFF
--- a/src/GitHubStatusDisplay.js
+++ b/src/GitHubStatusDisplay.js
@@ -9,6 +9,7 @@ import { summarize_job, summarize_date } from "./Summarize.js";
 import getGroups from "./groups/index.js";
 import Tooltip from "rc-tooltip";
 import axios from "axios";
+import UpdateButton from "./status/UpdateButton.js";
 import { BsFillCaretRightFill, BsFillCaretDownFill } from "react-icons/bs";
 import { ImSpinner2 } from "react-icons/im";
 import { FcCancel } from "react-icons/fc";
@@ -278,7 +279,7 @@ export default class BuildHistoryDisplay extends Component {
     const branch = this.props.branch;
     const user = this.props.user;
     const repo = this.props.repo;
-    const jsonUrl = `https://s3.amazonaws.com/ossci-job-status/v5/${user}/${repo}/${branch.replace(
+    const jsonUrl = `https://s3.amazonaws.com/ossci-job-status/v6/${user}/${repo}/${branch.replace(
       "/",
       "_"
     )}.json`;
@@ -917,7 +918,12 @@ export default class BuildHistoryDisplay extends Component {
     if (this.state.lastUpdateDate) {
       lastUpdate = (
         <p style={{ fontSize: "0.8em" }}>
-          Last updated {this.state.lastUpdateDate.toLocaleString()}
+          Last updated {this.state.lastUpdateDate.toLocaleString()}{" "}
+          <UpdateButton
+            repo={this.props.repo}
+            user={this.props.user}
+            branch={this.props.branch}
+          />
         </p>
       );
     }

--- a/src/status/UpdateButton.js
+++ b/src/status/UpdateButton.js
@@ -1,0 +1,99 @@
+import React, { Component } from "react";
+import Tooltip from "rc-tooltip";
+import Spin from "../Spin.js";
+
+// Button for triggering a GitHub Actions workflow to update the JSON backing
+// this user/repo/branch combo. If the user is not logged in, nothing is shown.
+// Otherwise, the button uses the GitHub OAuth token to trigger a
+// workflow_dispatch event for the relevant file.
+export default class UpdateButton extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      status: "waiting",
+    };
+  }
+
+  render() {
+    const token = localStorage.getItem("gh_pat");
+    if (!token) {
+      // Not logged in, don't show anything
+      return null;
+    }
+
+    // This should match the generated files here:
+    // https://github.com/pytorch/ci-hud/tree/main/.github/workflows
+    const workflowFile = `generated-update-github-status-${this.props.user}-${
+      this.props.repo
+    }-${this.props.branch.replace("/", "-")}.yml`;
+
+    if (this.state.status === "waiting") {
+      // No user actions yet, show the button
+      return (
+        <Tooltip
+          overlay={`Send a 'workflow_dispatch' event to GitHub Actions to run ${workflowFile}`}
+          mouseLeaveDelay={0}
+          placement="rightTop"
+          destroyTooltipOnHide={{ keepParent: false }}
+        >
+          <button
+            className="btn btn-info"
+            style={{
+              fontSize: "0.8em",
+              padding: "3px 8px 3px 8px",
+              marginLeft: "3px",
+            }}
+            onClick={async () => {
+              const url = `https://api.github.com/repos/pytorch/ci-hud/actions/workflows/${workflowFile}/dispatches`;
+              const body = {
+                ref: "main",
+              };
+
+              this.setState({ status: "sent" });
+
+              // Send in the request
+              fetch(url, {
+                method: "POST",
+                headers: {
+                  Authorization: `Bearer ${token}`,
+                },
+                body: JSON.stringify(body),
+              })
+                .then((r) => r.text())
+                .then((r) => {
+                  // Check if response has an error (it's empty if successful)
+                  if (r.includes("Not Found")) {
+                    // GitHub might send this back if the workflow name in the request
+                    // doesn't exist
+                    this.setState({ status: "error" });
+                  } else {
+                    this.setState({ status: "dispatched" });
+                  }
+                })
+                .catch(() => {});
+            }}
+          >
+            Update now
+          </button>
+        </Tooltip>
+      );
+    } else if (this.state.status === "sent") {
+      return <Spin text="Sending" />;
+    } else if (this.state.status === "dispatched") {
+      return (
+        <span>
+          <a
+            target="_blank"
+            rel="noreferrer"
+            href={`https://github.com/pytorch/ci-hud/actions/workflows/${workflowFile}`}
+          >
+            Successfully dispatched
+          </a>
+        </span>
+      );
+    } else if (this.state.status === "error") {
+      // Users shouldn't see this so something has gone wrong if they are
+      return <span>Unable to dispatch (file a bug)</span>;
+    }
+  }
+}


### PR DESCRIPTION
This switches from the Lambda based JSONs (`v5` in S3) to the ones generated by GitHub Actions (`v6` in S3). This also adds a button to the UI to trigger an immediate update. The benefit of this is that it's much easier to track and debug missing or bad updates. The main downside is GitHub's cron scheduler doesn't run very quickly or regularly, so the 'every 5 minutes' cron for pytorch/pytorch really runs every 7-10 minutes. This should be mitigated by the 'update now' button that this PR adds for logged in users.

![image](https://user-images.githubusercontent.com/9407960/140222981-32c86fa3-7612-4993-9baf-ae57c232ee4b.png)
