### PR TITLE
Add dropdown to view a previous commit on a PR

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -81,7 +81,14 @@ async function github_graphql_raw(query) {
   if (result.status !== 200) {
     throw new Error(`Error fetching data from GitHub: ${await result.text()}`);
   }
-  return await result.json();
+
+  const data = await result.json();
+  if (data.errors) {
+    throw new Error(
+      `Error in GraphQL response: ${JSON.stringify(data.errors)}`
+    );
+  }
+  return data;
 }
 
 async function github_graphql(query) {
@@ -109,6 +116,7 @@ export async function github_raw(url) {
       Authorization: "token " + pat,
     },
   });
+
   return result;
 }
 


### PR DESCRIPTION
This lets you see previous commit results as they were shown on the HUD when that commit was the tip via a dropdown of commit hashes. This is a step toward fixing #103 but not completely there since there's no way to see re-runs on the same commit yet.

![image](https://user-images.githubusercontent.com/9407960/140583788-e1d4adc1-6123-4079-8e35-d9261813fed5.png)
