### PR TITLE
Dynamically construct regex in guessRelevantLine

### DIFF
--- a/src/pr/FailureReport.js
+++ b/src/pr/FailureReport.js
@@ -33,7 +33,8 @@ function posToLine(text, idx) {
 }
 
 function guessRelevantLine(text, totalLines) {
-  const idx = Array.from(text.matchAll(/(?<!if-no-files-found: )error/g)).slice(
+  const regex = new RegExp("(?<!if-no-files-found: )error", "g");
+  const idx = Array.from(text.matchAll(regex)).slice(
     -1
   )[0].index;
   const line = posToLine(text, idx);

--- a/src/pr/FailureReport.js
+++ b/src/pr/FailureReport.js
@@ -33,6 +33,7 @@ function posToLine(text, idx) {
 }
 
 function guessRelevantLine(text, totalLines) {
+  // Safari (and perhaps others) do not support lookbehind regexes
   const genregex = () => {
     try {
       return new RegExp("(?<!if-no-files-found: )error", "g");

--- a/src/pr/FailureReport.js
+++ b/src/pr/FailureReport.js
@@ -36,14 +36,12 @@ function guessRelevantLine(text, totalLines) {
   const genregex = () => {
     try {
       return new RegExp("(?<!if-no-files-found: )error", "g");
-    } catch(e) {
+    } catch (e) {
       return new RegExp("error", "g");
     }
   };
   const regex = genregex();
-  const idx = Array.from(text.matchAll(regex)).slice(
-    -1
-  )[0].index;
+  const idx = Array.from(text.matchAll(regex)).slice(-1)[0].index;
   const line = posToLine(text, idx);
   return line;
 }

--- a/src/pr/FailureReport.js
+++ b/src/pr/FailureReport.js
@@ -33,7 +33,14 @@ function posToLine(text, idx) {
 }
 
 function guessRelevantLine(text, totalLines) {
-  const regex = new RegExp("(?<!if-no-files-found: )error", "g");
+  const genregex = () => {
+    try {
+      return new RegExp("(?<!if-no-files-found: )error", "g");
+    } catch(e) {
+      return new RegExp("error", "g");
+    }
+  };
+  const regex = genregex();
   const idx = Array.from(text.matchAll(regex)).slice(
     -1
   )[0].index;


### PR DESCRIPTION
Fixes parser error on Safari based browsers, which does not support [lookbehind regexes](https://caniuse.com/js-regexp-lookbehind)
Fixes https://github.com/pytorch/ci-hud/issues/192