### PR TITLE
Check that url is not null in `decoratedBuildUrl`

### DIFF
--- a/src/GitHubStatusDisplay.js
+++ b/src/GitHubStatusDisplay.js
@@ -712,7 +712,7 @@ export default class BuildHistoryDisplay extends Component {
           this.props.repo +
           "/runs/\\d+$"
       );
-      if (url.match(ghaRegex)) {
+      if (url && url.match(ghaRegex)) {
         return url + "?check_suite_focus=true";
       }
       return url;


### PR DESCRIPTION
Fixes https://github.com/pytorch/ci-hud/issues/195