### PR TITLE
refactor and add statuses next to branches

### DIFF
--- a/src/GitHubStatusDisplay.js
+++ b/src/GitHubStatusDisplay.js
@@ -264,7 +264,6 @@ export default class BuildHistoryDisplay extends Component {
       "/",
       "_"
     )}.json`;
-    console.log("JSON URL IS", jsonUrl);
     let commits = null;
     try {
       commits = await axios.get(jsonUrl);
@@ -364,6 +363,7 @@ export default class BuildHistoryDisplay extends Component {
         });
       }
     }
+
     this.setState(data);
   }
 

--- a/src/GitHubStatusDisplay.js
+++ b/src/GitHubStatusDisplay.js
@@ -264,6 +264,7 @@ export default class BuildHistoryDisplay extends Component {
       "/",
       "_"
     )}.json`;
+    console.log("JSON URL IS", jsonUrl);
     let commits = null;
     try {
       commits = await axios.get(jsonUrl);
@@ -363,7 +364,6 @@ export default class BuildHistoryDisplay extends Component {
         });
       }
     }
-
     this.setState(data);
   }
 

--- a/src/Links.js
+++ b/src/Links.js
@@ -3,11 +3,11 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-import React, { Component, Fragment } from "react";
+import React, { Component } from "react";
 import { AiFillGithub } from "react-icons/ai";
-import { Link } from "react-router-dom";
 import AuthorizeGitHub from "./AuthorizeGitHub";
-
+import LinkHeader from "./components/LinkHeader";
+import ShowMoreLinkHeader from "./components/ShowMoreLinkHeader";
 export default class Links extends Component {
   constructor(props) {
     super(props);
@@ -17,85 +17,6 @@ export default class Links extends Component {
   }
 
   render() {
-    let more = null;
-    if (this.state.showMore) {
-      more = (
-        <div>
-          <ul className="menu">
-            <li>Libraries:</li>
-            <li>
-              <Link to="/ci/pytorch/audio/main">audio</Link>
-            </li>
-            <li>
-              <Link to="/ci/pytorch/vision/main">vision</Link>
-            </li>
-            <li>
-              <Link to="/ci/pytorch/text/main">text</Link>
-            </li>
-            <li>
-              <Link to="/torchbench-v0-nightly">torchbench</Link>
-            </li>
-            <li>
-              <Link to="/ci/PyTorchLightning/pytorch-lightning/master">
-                pytorch-lightning
-              </Link>
-            </li>
-          </ul>
-          <ul className="deprecated-menu">
-            <li>Old-style:</li>
-            {[
-              "pytorch",
-              // "tensorcomp",
-              // "translate",
-              "rocm-pytorch",
-            ].map((e) => (
-              <Fragment key={e}>
-                {["master", "pull-request"].map((trigger) => (
-                  <li key={e + "-" + trigger}>
-                    <Link to={"/build1/" + e + "-" + trigger}>
-                      {e}-{trigger}
-                    </Link>
-                    &nbsp; (
-                    <Link to={"/build1/" + e + "-" + trigger + "?mode=perf"}>
-                      perf
-                    </Link>
-                    /
-                    <Link to={"/build1/" + e + "-" + trigger + "?mode=cost"}>
-                      cost
-                    </Link>
-                    {e === "pytorch" && trigger === "master" ? (
-                      <Fragment>
-                        /
-                        <Link
-                          to={"/build1/" + e + "-" + trigger + "?mode=binary"}
-                        >
-                          binary
-                        </Link>
-                      </Fragment>
-                    ) : (
-                      <Fragment />
-                    )}
-                    )
-                  </li>
-                ))}
-              </Fragment>
-            ))}
-            <Fragment key="nightlies-uploaded">
-              <li>
-                <Link to={"/build1/nightlies-uploaded"}>
-                  nightlies-uploaded
-                </Link>
-              </li>
-            </Fragment>
-          </ul>
-          <ul className="menu">
-            <li>
-              <Link to="/status">status</Link>
-            </li>
-          </ul>
-        </div>
-      );
-    }
     return (
       <div className="links-container">
         <div className="Links">
@@ -104,19 +25,7 @@ export default class Links extends Component {
               PyTorch CI HUD
             </a>
             <ul style={{ display: "inline" }} className="menu">
-              {["pytorch"].map((e) => (
-                <Fragment key={e}>
-                  {["master", "viable/strict", "nightly", "release/1.10"].map(
-                    (branch) => (
-                      <li key={`${branch}`}>
-                        <Link to={`/ci/pytorch/pytorch/${branch}`}>
-                          {branch}
-                        </Link>
-                      </li>
-                    )
-                  )}
-                </Fragment>
-              ))}
+              <LinkHeader />
               <li>
                 <a href="https://metrics.pytorch.org">metrics</a>
               </li>
@@ -170,7 +79,7 @@ export default class Links extends Component {
             </ul>
           </div>
         </div>
-        {more}
+        {this.state.showMore && <ShowMoreLinkHeader />}
       </div>
     );
   }

--- a/src/components/BranchLink.js
+++ b/src/components/BranchLink.js
@@ -1,0 +1,32 @@
+import React, { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import axios from "axios";
+import { is_failure, is_pending } from "../utils/JobStatusUtils";
+import ResultIcon from "./ResultIcon";
+export default function BranchLink({ jsonUrl, link, children }) {
+
+  const [commits, setCommits] = useState({});
+  useEffect(() => {
+    axios.get(jsonUrl).then((response) => {
+      setCommits(response.data);
+    });
+  }, [jsonUrl]);
+
+  let status = "success";
+  for (const job of commits[0]?.jobs ?? []) {
+    if (is_failure(job.status)) {
+      status = "failure";
+      break;
+    }
+    if (is_pending(job.status)) {
+      status = "pending;";
+    }
+  }
+
+  return (
+    <Link to={link}>
+      {children}
+      <ResultIcon result={status} />
+    </Link>
+  );
+}

--- a/src/components/BranchLink.js
+++ b/src/components/BranchLink.js
@@ -4,7 +4,6 @@ import axios from "axios";
 import { is_failure, is_pending } from "../utils/JobStatusUtils";
 import ResultIcon from "./ResultIcon";
 export default function BranchLink({ jsonUrl, link, children }) {
-
   const [commits, setCommits] = useState({});
   useEffect(() => {
     axios.get(jsonUrl).then((response) => {

--- a/src/components/LinkHeader.js
+++ b/src/components/LinkHeader.js
@@ -1,0 +1,20 @@
+import React from "react";
+import BranchLink from "./BranchLink";
+import { getStatusUrl, getLinkUrl } from "../utils/GetStatusUrlUtils";
+
+const BRANCHES = ["master", "viable/strict", "nightly", "release/1.10"];
+
+export default function LinkHeader() {
+  return BRANCHES.map((branch) => {
+    return (
+      <li key={`${branch}`}>
+        <BranchLink
+          jsonUrl={getStatusUrl("pytorch", "pytorch", branch)}
+          link={getLinkUrl("pytorch", "pytorch", branch)}
+        >
+          {branch + " "}
+        </BranchLink>
+      </li>
+    );
+  });
+}

--- a/src/components/ShowMoreLinkHeader.js
+++ b/src/components/ShowMoreLinkHeader.js
@@ -1,0 +1,93 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import BranchLink from "./BranchLink";
+import { getStatusUrl } from "../utils/GetStatusUrlUtils";
+export default function ShowMoreLinkHeader() {
+  const ExtraLibraries = () => {
+    const libraries = {
+      audio: { user: "pytorch", repo: "audio", branch: "main" },
+      vision: { user: "pytorch", repo: "vision", branch: "main" },
+      text: { user: "pytorch", repo: "text", branch: "main" },
+      "pytorch-lightning": {
+        user: "PyTorchLightning",
+        repo: "pytorch-lightning",
+        branch: "master",
+      },
+    };
+    return (
+      <ul className="menu">
+        <li>Libraries:</li>
+        {Object.keys(libraries).map((library, ind) => {
+          const { user, repo, branch } = libraries[library];
+          return (
+            <li key={ind}>
+              <BranchLink
+                jsonUrl={getStatusUrl(user, repo, branch)}
+                link={`/ci/${user}/${repo}/${branch}/`}
+              >
+                {library + " "}
+              </BranchLink>
+            </li>
+          );
+        })}
+      </ul>
+    );
+  };
+
+  const DeprecatedSection = () => {
+    const libraries = {
+      "pytorch-master": ["perf", "cost", "binary"],
+      "pytorch-pull-request": ["perf", "cost"],
+      // 'tensorcomp':[],
+      // 'translate': [],
+      "rocm-pytorch": ["perf", "cost"],
+      "rocm-pytorch-pull-request": ["perf", "cost"],
+    };
+
+    const DeprecatedLinks = () => {
+      const links = Object.keys(libraries).map((library, index) => {
+        return (
+          <React.Fragment key={index}>
+            <Link to={"/build1/" + library}>{library}</Link>
+            &nbsp;{"("}
+            {libraries[library].map((mode, ind) => {
+              return (
+                <Link key={ind} to={"/build1/" + library + `?mode=${mode}`}>
+                  {mode}
+                  {ind !== libraries[library].length - 1 ? "/" : ""}
+                </Link>
+              );
+            })}
+            {")"}&nbsp;
+          </React.Fragment>
+        );
+      });
+      return links;
+    };
+    return (
+      <ul className="deprecated-menu">
+        <li>Old-style:</li>
+        <DeprecatedLinks />
+        <Link to={"/build1/nightlies-uploaded"}> nightlies-uploaded</Link>
+      </ul>
+    );
+  };
+
+  const Status = () => {
+    return (
+      <ul className="menu">
+        <li>
+          <Link to="/status">status</Link>
+        </li>
+      </ul>
+    );
+  };
+
+  return (
+    <div>
+      <ExtraLibraries />
+      <DeprecatedSection />
+      <Status />
+    </div>
+  );
+}

--- a/src/components/ShowMoreLinkHeader.js
+++ b/src/components/ShowMoreLinkHeader.js
@@ -30,6 +30,9 @@ export default function ShowMoreLinkHeader() {
             </li>
           );
         })}
+        <li>
+          <Link to="/torchbench-v0-nightly">torchbench</Link>
+        </li>
       </ul>
     );
   };

--- a/src/utils/GetStatusUrlUtils.js
+++ b/src/utils/GetStatusUrlUtils.js
@@ -1,0 +1,10 @@
+export function getStatusUrl(user, repo, branch) {
+  return `https://s3.amazonaws.com/ossci-job-status/v6/${user}/${repo}/${branch.replace(
+    "/",
+    "_"
+  )}.json`;
+}
+
+export function getLinkUrl(user, repo, branch) {
+  return `/ci/${user}/${repo}/${branch}/`;
+}


### PR DESCRIPTION
#121 

This adds a status indicator to the right of the branch for the newer repos.

![image](https://user-images.githubusercontent.com/34172846/147595150-f561abbc-cda7-467e-82de-a9b749e12b94.png)
